### PR TITLE
fix(asr): stop silently dropping utterances and remove scoring hot spots

### DIFF
--- a/src/sure_eval/evaluation/nodes/normalization/aispeech_norm/README.md
+++ b/src/sure_eval/evaluation/nodes/normalization/aispeech_norm/README.md
@@ -13,3 +13,16 @@ Profiles:
 - `zh`: AISpeech number text normalization plus punctuation stripping.
 - `cs`: AISpeech code-switch tokenization, language split, and number text
   normalization.
+
+Input handling:
+
+- Rows are `<key>\t<text>`. A row whose text is empty is a valid recognition
+  result and is preserved, so downstream scoring counts it as deletions instead
+  of silently dropping the utterance.
+- Non-empty lines without a tab separator are dropped and counted in the node
+  trace under `row_stats`. If a file yields no parseable rows at all, the node
+  raises instead of producing an empty (and trivially perfect) evaluation.
+- Normalization map tables are loaded once per node call and shared across
+  rows (with a shared number-conversion cache), instead of re-globbing and
+  re-reading map files for every line/token. Output is identical; the
+  per-call fallback inside `asr_num2words` remains for legacy callers.

--- a/src/sure_eval/evaluation/nodes/normalization/aispeech_norm/node.py
+++ b/src/sure_eval/evaluation/nodes/normalization/aispeech_norm/node.py
@@ -6,6 +6,8 @@ This node preserves the normalization behavior currently embedded in
 
 from __future__ import annotations
 
+import glob
+import os
 import tempfile
 from pathlib import Path
 
@@ -29,12 +31,17 @@ def normalize_asr_files(files: KeyTextFiles, *, language: str) -> tuple[KeyTextF
     """Normalize key-text ASR reference and hypothesis files."""
 
     map_dir = _default_map_dir()
+    norm_context = _make_norm_context(language, map_dir)
 
     ref_norm_file = _new_temp_file()
     hyp_norm_file = _new_temp_file()
     try:
-        _write_normalized_file(files.ref_file, ref_norm_file, language=language, map_dir=map_dir)
-        _write_normalized_file(files.hyp_file, hyp_norm_file, language=language, map_dir=map_dir)
+        ref_stats = _write_normalized_file(
+            files.ref_file, ref_norm_file, language=language, norm_context=norm_context
+        )
+        hyp_stats = _write_normalized_file(
+            files.hyp_file, hyp_norm_file, language=language, norm_context=norm_context
+        )
         _strip_eval_punct_file(ref_norm_file)
         _strip_eval_punct_file(hyp_norm_file)
     except Exception:
@@ -55,6 +62,7 @@ def normalize_asr_files(files: KeyTextFiles, *, language: str) -> tuple[KeyTextF
                 "punctuation_policy": "SUREEvaluator._strip_eval_punct_file",
                 "ref_file": ref_norm_file,
                 "hyp_file": hyp_norm_file,
+                "row_stats": {"ref": ref_stats, "hyp": hyp_stats},
             },
             internal_stages=("number_text_normalization", "punctuation_stripping"),
         ),
@@ -64,21 +72,20 @@ def normalize_asr_files(files: KeyTextFiles, *, language: str) -> tuple[KeyTextF
 def normalize_codeswitch_asr_files(files: KeyTextFiles) -> tuple[KeyTextFiles, PipelineNodeResult]:
     """Normalize code-switch ASR files into mixed, zh-only, and en-only key-text files."""
 
-    from sure_eval.evaluation.nodes.normalization.aispeech_norm.normalization_impl.asr_simple_tn import asr_num2words
-
     map_dir = _default_map_dir()
 
     class Preprocessor:
         def __init__(self, lang: str):
             self.lang = lang
+            self.norm_context = _make_norm_context(lang, map_dir)
 
         def normalize(self, text: str) -> str:
-            return asr_num2words(text, self.lang, map_dir=map_dir, debug=False)
+            return _normalize_text(text, self.lang, self.norm_context)
 
     proc_en = Preprocessor("en")
     proc_zh = Preprocessor("zh")
-    ref_lines, ref_zh_lines, ref_en_lines = _codeswitch_rows(files.ref_file, proc_en, proc_zh)
-    hyp_lines, hyp_zh_lines, hyp_en_lines = _codeswitch_rows(files.hyp_file, proc_en, proc_zh)
+    ref_lines, ref_zh_lines, ref_en_lines, ref_stats = _codeswitch_rows(files.ref_file, proc_en, proc_zh)
+    hyp_lines, hyp_zh_lines, hyp_en_lines, hyp_stats = _codeswitch_rows(files.hyp_file, proc_en, proc_zh)
 
     temp_paths: list[str] = []
     try:
@@ -106,6 +113,7 @@ def normalize_codeswitch_asr_files(files: KeyTextFiles) -> tuple[KeyTextFiles, P
                 "profile": "cs",
                 "text_normalizer": "asr_num2words",
                 "side_outputs": outputs,
+                "row_stats": {"ref": ref_stats, "hyp": hyp_stats},
             },
             internal_stages=("codeswitch_tokenization", "number_text_normalization", "language_split"),
         ),
@@ -119,36 +127,143 @@ def _new_temp_file() -> str:
     return path
 
 
-def _write_normalized_file(input_file: str, output_file: str, *, language: str, map_dir: str) -> None:
+def _load_num2words_maps(language: str, map_dir: str) -> tuple[list, list]:
+    """Preload the map tables ``asr_num2words`` would otherwise re-read per call.
+
+    Mirrors the function's own fallback lookup: non-digit ``<map_dir>/*.map``
+    files for text replacement, then ``<map_dir>/<language>/digit.map`` (or the
+    root ``digit.map``) for digit-by-digit conversion.
+    """
+
+    from sure_eval.evaluation.nodes.normalization.aispeech_norm.normalization_impl.asr_simple_tn import (
+        load_and_sort_map,
+    )
+
+    other_map_sorted: list = []
+    for map_file in sorted(glob.glob(os.path.join(map_dir, "*.map"))):
+        if os.path.basename(map_file) != "digit.map":
+            other_map_sorted.extend(load_and_sort_map(map_file, language))
+    other_map_sorted.sort(key=lambda pair: len(pair[0]), reverse=True)
+
+    lang_map_file = os.path.join(map_dir, language, "digit.map")
+    root_map_file = os.path.join(map_dir, "digit.map")
+    if os.path.exists(lang_map_file):
+        digit_map_file = lang_map_file
+    elif os.path.exists(root_map_file):
+        digit_map_file = root_map_file
+    else:
+        digit_map_file = None
+    digit_map_sorted = load_and_sort_map(digit_map_file, language) if digit_map_file else []
+    return other_map_sorted, digit_map_sorted
+
+
+def _make_norm_context(language: str, map_dir: str) -> dict:
+    """Bundle preloaded maps and a shared number cache for repeated calls."""
+
+    other_map_sorted, digit_map_sorted = _load_num2words_maps(language, map_dir)
+    return {
+        "map_dir": map_dir,
+        "other_map_sorted": other_map_sorted,
+        "digit_map_sorted": digit_map_sorted,
+        "cached_num_map": {},
+    }
+
+
+def _normalize_text(text: str, language: str, norm_context: dict) -> str:
     from sure_eval.evaluation.nodes.normalization.aispeech_norm.normalization_impl.asr_simple_tn import asr_num2words
 
-    rows = []
+    return asr_num2words(
+        text,
+        language,
+        map_dir=norm_context["map_dir"],
+        debug=False,
+        other_map_sorted=norm_context["other_map_sorted"],
+        digit_map_sorted=norm_context["digit_map_sorted"],
+        cached_num_map=norm_context["cached_num_map"],
+    )
+
+
+def _write_normalized_file(input_file: str, output_file: str, *, language: str, norm_context: dict) -> dict[str, int]:
+    rows: list[str] = []
+    num_empty_text_rows = 0
+    num_dropped_malformed_rows = 0
     with open(input_file, "r", encoding="utf-8") as handle:
         for line in handle:
-            parts = line.strip().split("\t", 1)
-            if len(parts) == 2:
-                key, text = parts
-                text_norm = asr_num2words(text, language, map_dir=map_dir, debug=False)
-                rows.append(f"{key}\t{text_norm}")
-    Path(output_file).write_text("\n".join(rows) + "\n", encoding="utf-8")
+            key, text = _parse_key_text_line(line)
+            if key is None:
+                if text is not None:
+                    num_dropped_malformed_rows += 1
+                continue
+            if text:
+                text_norm = _normalize_text(text, language, norm_context)
+            else:
+                num_empty_text_rows += 1
+                text_norm = ""
+            rows.append(f"{key}\t{text_norm}")
+    _require_parsed_rows(input_file, num_rows=len(rows), num_malformed=num_dropped_malformed_rows)
+    Path(output_file).write_text("\n".join(rows) + "\n" if rows else "", encoding="utf-8")
+    return {
+        "num_rows": len(rows),
+        "num_empty_text_rows": num_empty_text_rows,
+        "num_dropped_malformed_rows": num_dropped_malformed_rows,
+    }
 
 
-def _codeswitch_rows(input_file: str, proc_en, proc_zh) -> tuple[list[str], list[str], list[str]]:
+def _parse_key_text_line(line: str) -> tuple[str | None, str | None]:
+    """Parse one ``<key>\\t<text>`` row; empty text is a valid recognition result.
+
+    Returns ``(key, text)`` for parsed rows, ``(None, None)`` for blank lines,
+    and ``(None, raw)`` for malformed rows without a tab separator or key.
+    """
+
+    raw = line.rstrip("\r\n")
+    if not raw.strip():
+        return None, None
+    if "\t" not in raw:
+        return None, raw
+    key, text = raw.split("\t", 1)
+    key = key.strip()
+    if not key:
+        return None, raw
+    return key, text.strip()
+
+
+def _require_parsed_rows(input_file: str, *, num_rows: int, num_malformed: int) -> None:
+    if num_rows == 0 and num_malformed > 0:
+        raise ValueError(
+            f"No <key>\\t<text> rows could be parsed from {input_file!r} "
+            f"({num_malformed} non-empty lines without a tab separator). "
+            "ASR key-text inputs must be tab-separated."
+        )
+
+
+def _codeswitch_rows(input_file: str, proc_en, proc_zh) -> tuple[list[str], list[str], list[str], dict[str, int]]:
     mixed_lines: list[str] = []
     zh_lines: list[str] = []
     en_lines: list[str] = []
+    num_empty_text_rows = 0
+    num_dropped_malformed_rows = 0
     with open(input_file, "r", encoding="utf-8") as handle:
         for line in handle:
-            parts = line.strip().split("\t", 1)
-            if len(parts) != 2:
+            key, text = _parse_key_text_line(line)
+            if key is None:
+                if text is not None:
+                    num_dropped_malformed_rows += 1
                 continue
-            key, text = parts
-            tokens = tokenize_codeswitch(text, proc_en, proc_zh)
+            if not text:
+                num_empty_text_rows += 1
+            tokens = tokenize_codeswitch(text, proc_en, proc_zh) if text else []
             zh_tokens, en_tokens = split_tokens(tokens)
             mixed_lines.append(f"{key}\t{' '.join(tokens)}")
             zh_lines.append(f"{key}\t{' '.join(zh_tokens)}")
             en_lines.append(f"{key}\t{' '.join(en_tokens)}")
-    return mixed_lines, zh_lines, en_lines
+    _require_parsed_rows(input_file, num_rows=len(mixed_lines), num_malformed=num_dropped_malformed_rows)
+    stats = {
+        "num_rows": len(mixed_lines),
+        "num_empty_text_rows": num_empty_text_rows,
+        "num_dropped_malformed_rows": num_dropped_malformed_rows,
+    }
+    return mixed_lines, zh_lines, en_lines, stats
 
 
 def _write_temp_rows(rows: list[str], temp_paths: list[str]) -> str:

--- a/src/sure_eval/evaluation/nodes/normalization/aispeech_norm/normalization_impl/asr_simple_tn.py
+++ b/src/sure_eval/evaluation/nodes/normalization/aispeech_norm/normalization_impl/asr_simple_tn.py
@@ -58,6 +58,18 @@ def get_n2w_map(map_file, language=None):
     #print(n2w_map, file=sys.stderr)
     return n2w_map
 
+def load_and_sort_map(map_file, language=None):
+    """Load one .map file into (key, value) pairs sorted by key length desc."""
+    n2w_map = get_n2w_map(map_file, language)
+    if not n2w_map:
+        return []
+    pairs = []
+    for item in n2w_map:
+        pairs.extend(item.items())
+    pairs.sort(key=lambda x: len(x[0]), reverse=True)
+    return pairs
+
+
 def tn_replace(text, key, value):
     pattern = None
     if key[0:2] == "\\b" or key[-2:] == "\\b": # 目前仅支持在首尾加单词边界符
@@ -253,7 +265,7 @@ def asr_num2words(
         map_files = glob.glob(os.path.join(map_dir, "*.map"))
         for mf in map_files:
             if os.path.basename(mf) != "digit.map":
-                pairs.extend(load_and_sort_map(mf))
+                pairs.extend(load_and_sort_map(mf, language))
         pairs.sort(key=lambda x: len(x[0]), reverse=True)
     text2 = text
     for key, value in pairs:

--- a/src/sure_eval/evaluation/nodes/scoring/wenet_wer/README.md
+++ b/src/sure_eval/evaluation/nodes/scoring/wenet_wer/README.md
@@ -6,3 +6,22 @@ The wrapped script is treated as a composite scoring backend because it includes
 tokenization, optional character splitting, case normalization, tag stripping,
 and edit-distance counting. The pipeline report records these internal stages
 instead of pretending the backend is only a single edit-distance function.
+
+The vendored `compute_wer` script keeps upstream WeNet scoring semantics. The
+only intentional deviation is performance-only: the DP matrix reset touches
+just the submatrix a given utterance uses, instead of every previously grown
+row. Upstream reset made every utterance after one long utterance pay
+O(longest^2), which turned long-form corpora with one long hypothesis into
+multi-minute runs; scores are unchanged and covered by an order-independence
+regression test.
+
+Utterance coverage is enforced in the wrapper layer:
+
+- Reference utterances missing from the hypothesis file are scored as empty
+  hypotheses (pure deletions) rather than silently skipped. The scoring result
+  reports `num_ref_utts`, `num_hyp_utts`, `num_hyp_missing_utts`,
+  `num_hyp_extra_utts`, and key samples for any mismatch.
+- If scoring covers zero reference tokens (empty or malformed inputs, or fully
+  disjoint keys), the node raises instead of reporting a perfect 0.0 error
+  rate. The zh-only / en-only side scores of the code-switch MER route stay
+  lenient because a monolingual subset legitimately covers zero tokens.

--- a/src/sure_eval/evaluation/nodes/scoring/wenet_wer/node.py
+++ b/src/sure_eval/evaluation/nodes/scoring/wenet_wer/node.py
@@ -2,17 +2,22 @@
 
 from __future__ import annotations
 
+import tempfile
+from pathlib import Path
+
 from sure_eval.evaluation.core.types import KeyTextFiles, PipelineNodeResult
 from sure_eval.evaluation.nodes.scoring.wenet_wer.wenet_compute_cer import compute_wer
 
 NODE_VERSION = "v1"
 INTERNAL_STAGES = ("tokenization", "case_normalization", "edit_distance")
+_MISSING_KEYS_SAMPLE_LIMIT = 10
 
 
 def score_wenet_wer(files: KeyTextFiles) -> tuple[KeyTextFiles, PipelineNodeResult]:
     """Score normalized key-text files with WeNet WER semantics."""
 
-    result = compute_wer(files.ref_file, files.hyp_file, tochar=False)
+    result = _compute_wer_with_coverage(files.ref_file, files.hyp_file, tochar=False)
+    _require_scored_tokens(result, metric="wer", ref_file=files.ref_file, hyp_file=files.hyp_file)
     score = _rate(result)
     result["wer"] = score
     result["wer_percent"] = score * 100
@@ -32,7 +37,8 @@ def score_wenet_wer(files: KeyTextFiles) -> tuple[KeyTextFiles, PipelineNodeResu
 def score_wenet_cer(files: KeyTextFiles) -> tuple[KeyTextFiles, PipelineNodeResult]:
     """Score normalized key-text files with WeNet CER semantics."""
 
-    result = compute_wer(files.ref_file, files.hyp_file, tochar=True)
+    result = _compute_wer_with_coverage(files.ref_file, files.hyp_file, tochar=True)
+    _require_scored_tokens(result, metric="cer", ref_file=files.ref_file, hyp_file=files.hyp_file)
     score = _rate(result)
     result["cer"] = score
     result["cer_percent"] = score * 100
@@ -53,9 +59,17 @@ def score_codeswitch_mer(files: KeyTextFiles, *, normalization_details: dict) ->
     """Score code-switch ASR with the same MER/WER/CER decomposition as legacy ASR."""
 
     side_outputs = normalization_details["side_outputs"]
-    mer_result = compute_wer(side_outputs["ref_file"], side_outputs["hyp_file"])
-    cer_result = compute_wer(side_outputs["ref_zh_file"], side_outputs["hyp_zh_file"], tochar=True)
-    wer_result = compute_wer(side_outputs["ref_en_file"], side_outputs["hyp_en_file"])
+    mer_result = _compute_wer_with_coverage(side_outputs["ref_file"], side_outputs["hyp_file"])
+    _require_scored_tokens(
+        mer_result,
+        metric="mer",
+        ref_file=side_outputs["ref_file"],
+        hyp_file=side_outputs["hyp_file"],
+    )
+    # zh-only / en-only side scores may legitimately cover zero tokens
+    # (e.g. a monolingual subset), so they stay lenient.
+    cer_result = _compute_wer_with_coverage(side_outputs["ref_zh_file"], side_outputs["hyp_zh_file"], tochar=True)
+    wer_result = _compute_wer_with_coverage(side_outputs["ref_en_file"], side_outputs["hyp_en_file"])
     mer_score = _rate(mer_result)
     cer_score = _rate(cer_result)
     wer_score = _rate(wer_result)
@@ -81,6 +95,82 @@ def score_codeswitch_mer(files: KeyTextFiles, *, normalization_details: dict) ->
             internal_stages=("mixed_token_scoring", "zh_cer_scoring", "en_wer_scoring"),
         ),
     )
+
+
+def _compute_wer_with_coverage(ref_file: str, hyp_file: str, *, tochar: bool = False) -> dict:
+    """Run ``compute_wer`` with utterance-coverage accounting.
+
+    ``compute_wer`` silently skips reference utterances whose key is absent
+    from the hypothesis file. This wrapper scores those utterances as empty
+    hypotheses (pure deletions) instead, and reports coverage counts so a
+    partial or mismatched hypothesis file can never pass as a clean run.
+    """
+
+    ref_keys = _read_utt_keys(ref_file)
+    hyp_keys = _read_utt_keys(hyp_file)
+    hyp_key_set = set(hyp_keys)
+    ref_key_set = set(ref_keys)
+    missing_keys = [key for key in ref_keys if key not in hyp_key_set]
+    extra_keys = [key for key in hyp_keys if key not in ref_key_set]
+
+    scored_hyp_file = hyp_file
+    filled_hyp_file: str | None = None
+    try:
+        if missing_keys:
+            filled_hyp_file = _fill_missing_hyp_utts(hyp_file, missing_keys)
+            scored_hyp_file = filled_hyp_file
+        result = compute_wer(ref_file, scored_hyp_file, tochar=tochar)
+    finally:
+        if filled_hyp_file is not None:
+            Path(filled_hyp_file).unlink(missing_ok=True)
+
+    result["num_ref_utts"] = len(ref_keys)
+    result["num_hyp_utts"] = len(hyp_keys)
+    result["num_hyp_missing_utts"] = len(missing_keys)
+    result["num_hyp_extra_utts"] = len(extra_keys)
+    if missing_keys:
+        result["hyp_missing_keys_sample"] = missing_keys[:_MISSING_KEYS_SAMPLE_LIMIT]
+        result["hyp_missing_policy"] = "scored_as_empty_hypothesis"
+    if extra_keys:
+        result["hyp_extra_keys_sample"] = extra_keys[:_MISSING_KEYS_SAMPLE_LIMIT]
+    return result
+
+
+def _read_utt_keys(path: str) -> list[str]:
+    # Key extraction mirrors compute_wer: the first whitespace-delimited token.
+    keys: list[str] = []
+    with open(path, "r", encoding="utf-8") as handle:
+        for line in handle:
+            parts = line.split()
+            if parts:
+                keys.append(parts[0])
+    return keys
+
+
+def _fill_missing_hyp_utts(hyp_file: str, missing_keys: list[str]) -> str:
+    handle = tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False, encoding="utf-8")
+    try:
+        with open(hyp_file, "r", encoding="utf-8") as source:
+            content = source.read()
+        handle.write(content)
+        if content and not content.endswith("\n"):
+            handle.write("\n")
+        for key in missing_keys:
+            handle.write(f"{key}\t\n")
+    finally:
+        handle.close()
+    return handle.name
+
+
+def _require_scored_tokens(result: dict, *, metric: str, ref_file: str, hyp_file: str) -> None:
+    if result["all"] == 0:
+        raise ValueError(
+            f"ASR {metric} scoring covered zero reference tokens "
+            f"({result.get('num_ref_utts', 0)} reference utterances parsed from {ref_file!r}, "
+            f"{result.get('num_hyp_utts', 0)} hypothesis utterances parsed from {hyp_file!r}). "
+            "Refusing to report a 0.0 error rate; check that both inputs are non-empty "
+            "tab-separated <key>\\t<text> files with matching keys."
+        )
 
 
 def _rate(result: dict) -> float:

--- a/src/sure_eval/evaluation/nodes/scoring/wenet_wer/wenet_compute_cer.py
+++ b/src/sure_eval/evaluation/nodes/scoring/wenet_wer/wenet_compute_cer.py
@@ -106,15 +106,21 @@ class Calculator:
         lab = [''] + list(lab)
         rec = [''] + list(rec)
         
-        # Initialize space matrix
+        # Initialize space matrix. Only the len(lab) x len(rec) submatrix is
+        # read by the DP and trace-back below, so only that region is reset.
+        # Resetting every previously grown row (upstream behavior) made every
+        # utterance after one long utterance pay O(max_len^2); scores are
+        # identical either way.
         while len(self.space) < len(lab):
             self.space.append([])
-        for row in self.space:
-            for element in row:
-                element['dist'] = 0
-                element['error'] = 'non'
+        for i in range(len(lab)):
+            row = self.space[i]
             while len(row) < len(rec):
                 row.append({'dist': 0, 'error': 'non'})
+            for j in range(len(rec)):
+                element = row[j]
+                element['dist'] = 0
+                element['error'] = 'non'
         
         # Initialize borders
         for i in range(len(lab)):

--- a/tests/test_asr_pipeline_nodes.py
+++ b/tests/test_asr_pipeline_nodes.py
@@ -7,6 +7,16 @@ def _write_key_text(path: Path, rows: list[tuple[str, str]]) -> None:
     path.write_text("".join(f"{key}\t{text}\n" for key, text in rows), encoding="utf-8")
 
 
+def _assert_matches_legacy(actual: dict, legacy: dict) -> None:
+    """Every legacy field must match; scoring results may add coverage fields."""
+
+    for key, value in legacy.items():
+        if isinstance(value, dict):
+            _assert_matches_legacy(actual[key], value)
+        else:
+            assert actual[key] == value, f"legacy field {key!r} diverged"
+
+
 def _fake_wetext_normalizer(files, *, profile: str):
     from sure_eval.evaluation.core.types import PipelineNodeResult
 
@@ -90,7 +100,7 @@ def test_asr_zh_cer_pipeline_matches_sure_evaluator(tmp_path: Path) -> None:
     assert report.language == "zh"
     assert report.metric == "cer"
     assert report.score == legacy["score"]
-    assert report.details["scoring_result"] == legacy
+    _assert_matches_legacy(report.details["scoring_result"], legacy)
     assert report.details["input_contract"]["required_roles"] == ["hyp", "ref"]
     assert report.details["input_contract"]["aggregation"] == "corpus_edit_distance"
     assert report.details["input_files"] == {"ref": str(ref_file), "hyp": str(hyp_file)}
@@ -144,7 +154,7 @@ def test_asr_en_wer_pipeline_can_use_legacy_aispeech_normalization(tmp_path: Pat
     )
 
     assert report.score == legacy["score"]
-    assert report.details["scoring_result"] == legacy
+    _assert_matches_legacy(report.details["scoring_result"], legacy)
     assert report.pipeline_id == "asr.en.wer.aispeech_norm.wenet_wer"
     assert report.pipeline_trace[0].node_id == "normalization/aispeech_norm"
     assert report.pipeline_trace[0].details["profile"] == "en"
@@ -323,7 +333,7 @@ def test_asr_codeswitch_mer_pipeline_matches_sure_evaluator(tmp_path: Path) -> N
     assert report.language == "cs"
     assert report.metric == "mer"
     assert report.score == legacy["score"]
-    assert report.details["scoring_result"] == legacy
+    _assert_matches_legacy(report.details["scoring_result"], legacy)
     assert report.details["input_contract"]["required_roles"] == ["hyp", "ref"]
     assert report.details["input_contract"]["metric_id"] == "scoring/wenet_mer"
     assert report.pipeline_trace[0].node_id == "normalization/aispeech_norm"

--- a/tests/test_asr_scoring_coverage.py
+++ b/tests/test_asr_scoring_coverage.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _write_key_text(path: Path, rows: list[tuple[str, str]]) -> None:
+    path.write_text("".join(f"{key}\t{text}\n" for key, text in rows), encoding="utf-8")
+
+
+def test_asr_zh_cer_scores_empty_hypothesis_text_as_deletions(tmp_path: Path) -> None:
+    from sure_eval.evaluation.tasks.asr.pipeline import evaluate_asr_files
+
+    ref_file = tmp_path / "ref.txt"
+    hyp_file = tmp_path / "hyp.txt"
+    _write_key_text(ref_file, [("utt1", "今天天气很好"), ("utt2", "我们一起去公园")])
+    _write_key_text(hyp_file, [("utt1", "今天天气很好"), ("utt2", "")])
+
+    report = evaluate_asr_files(str(ref_file), str(hyp_file), language="zh", metric="cer")
+    result = report.details["scoring_result"]
+
+    assert result["all"] == 13
+    assert result["del"] == 7
+    assert report.score == pytest.approx(7 / 13)
+
+
+def test_asr_zh_cer_scores_missing_hypothesis_utterance_as_deletions(tmp_path: Path) -> None:
+    from sure_eval.evaluation.tasks.asr.pipeline import evaluate_asr_files
+
+    ref_file = tmp_path / "ref.txt"
+    hyp_file = tmp_path / "hyp.txt"
+    _write_key_text(ref_file, [("utt1", "今天天气很好"), ("utt2", "我们一起去公园")])
+    _write_key_text(hyp_file, [("utt1", "今天天气很好")])
+
+    report = evaluate_asr_files(str(ref_file), str(hyp_file), language="zh", metric="cer")
+    result = report.details["scoring_result"]
+
+    assert result["num_ref_utts"] == 2
+    assert result["num_hyp_utts"] == 1
+    assert result["num_hyp_missing_utts"] == 1
+    assert result["hyp_missing_keys_sample"] == ["utt2"]
+    assert result["hyp_missing_policy"] == "scored_as_empty_hypothesis"
+    assert result["all"] == 13
+    assert result["del"] == 7
+    assert report.score == pytest.approx(7 / 13)
+
+
+def test_asr_scoring_result_reports_utterance_coverage(tmp_path: Path) -> None:
+    from sure_eval.evaluation.tasks.asr.pipeline import evaluate_asr_files
+
+    ref_file = tmp_path / "ref.txt"
+    hyp_file = tmp_path / "hyp.txt"
+    _write_key_text(ref_file, [("utt1", "今天天气很好")])
+    _write_key_text(hyp_file, [("utt1", "今天天气很好"), ("utt9", "多余的行")])
+
+    report = evaluate_asr_files(str(ref_file), str(hyp_file), language="zh", metric="cer")
+    result = report.details["scoring_result"]
+
+    assert result["num_ref_utts"] == 1
+    assert result["num_hyp_utts"] == 2
+    assert result["num_hyp_missing_utts"] == 0
+    assert result["num_hyp_extra_utts"] == 1
+    assert result["hyp_extra_keys_sample"] == ["utt9"]
+    assert report.score == 0.0
+
+
+def test_asr_zh_cer_rejects_inputs_without_tab_separator(tmp_path: Path) -> None:
+    from sure_eval.evaluation.tasks.asr.pipeline import evaluate_asr_files
+
+    ref_file = tmp_path / "ref.txt"
+    hyp_file = tmp_path / "hyp.txt"
+    ref_file.write_text("utt1 今天天气很好\nutt2 我们一起去公园\n", encoding="utf-8")
+    hyp_file.write_text("utt1 今天天气很好\nutt2 我们一起去公园\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="tab-separated"):
+        evaluate_asr_files(str(ref_file), str(hyp_file), language="zh", metric="cer")
+
+
+def test_asr_en_wer_rejects_inputs_that_score_zero_reference_tokens(tmp_path: Path) -> None:
+    from sure_eval.evaluation.tasks.asr.pipeline import evaluate_asr_files
+
+    ref_file = tmp_path / "ref.txt"
+    hyp_file = tmp_path / "hyp.txt"
+    ref_file.write_text("utt1 hello world\n", encoding="utf-8")
+    hyp_file.write_text("utt1 hello world\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="zero reference tokens"):
+        evaluate_asr_files(str(ref_file), str(hyp_file), language="en", metric="wer")
+
+
+def test_asr_normalization_keeps_empty_hypothesis_rows(tmp_path: Path) -> None:
+    from sure_eval.evaluation.core.types import KeyTextFiles
+    from sure_eval.evaluation.nodes.normalization.aispeech_norm import normalize_asr_files
+
+    ref_file = tmp_path / "ref.txt"
+    hyp_file = tmp_path / "hyp.txt"
+    _write_key_text(ref_file, [("utt1", "今天天气很好"), ("utt2", "我们一起去公园")])
+    _write_key_text(hyp_file, [("utt1", "今天天气很好"), ("utt2", "")])
+
+    normalized, result = normalize_asr_files(
+        KeyTextFiles(ref_file=str(ref_file), hyp_file=str(hyp_file)), language="zh"
+    )
+    try:
+        hyp_lines = Path(normalized.hyp_file).read_text(encoding="utf-8").splitlines()
+        assert hyp_lines == ["utt1\t今天天气很好", "utt2\t"]
+        assert result.details["row_stats"]["hyp"] == {
+            "num_rows": 2,
+            "num_empty_text_rows": 1,
+            "num_dropped_malformed_rows": 0,
+        }
+    finally:
+        Path(normalized.ref_file).unlink(missing_ok=True)
+        Path(normalized.hyp_file).unlink(missing_ok=True)
+
+
+def test_asr_codeswitch_mer_scores_empty_hypothesis_text_as_deletions(tmp_path: Path) -> None:
+    from sure_eval.evaluation.tasks.asr.pipeline import evaluate_asr_files
+
+    ref_file = tmp_path / "ref.txt"
+    hyp_file = tmp_path / "hyp.txt"
+    _write_key_text(ref_file, [("utt1", "你好 world")])
+    _write_key_text(hyp_file, [("utt1", "")])
+
+    report = evaluate_asr_files(str(ref_file), str(hyp_file), language="cs", metric="mer")
+    result = report.details["scoring_result"]
+
+    assert report.score == pytest.approx(1.0)
+    assert result["mer_details"]["all"] == 3
+    assert result["mer_details"]["del"] == 3
+
+
+def test_wenet_compute_wer_totals_do_not_depend_on_utterance_order(tmp_path: Path) -> None:
+    from sure_eval.evaluation.nodes.scoring.wenet_wer.wenet_compute_cer import compute_wer
+
+    long_row = ("ulong", " ".join(["tok"] * 300))
+    short_ref = [(f"u{i:03d}", "aa bb cc dd") for i in range(50)]
+    short_hyp = [(f"u{i:03d}", "aa bb cc xx") for i in range(50)]  # one sub each
+
+    totals = {}
+    for order in ("long_first", "long_last"):
+        ref_rows = [long_row] + short_ref if order == "long_first" else short_ref + [long_row]
+        hyp_rows = [long_row] + short_hyp if order == "long_first" else short_hyp + [long_row]
+        ref_file = tmp_path / f"ref_{order}.txt"
+        hyp_file = tmp_path / f"hyp_{order}.txt"
+        _write_key_text(ref_file, ref_rows)
+        _write_key_text(hyp_file, hyp_rows)
+        result = compute_wer(str(ref_file), str(hyp_file))
+        totals[order] = {key: result[key] for key in ("all", "cor", "sub", "del", "ins")}
+
+    assert totals["long_first"] == totals["long_last"]
+    assert totals["long_first"]["all"] == 300 + 50 * 4
+    assert totals["long_first"]["sub"] == 50
+
+
+def test_asr_codeswitch_mer_allows_monolingual_side_scores(tmp_path: Path) -> None:
+    from sure_eval.evaluation.tasks.asr.pipeline import evaluate_asr_files
+
+    ref_file = tmp_path / "ref.txt"
+    hyp_file = tmp_path / "hyp.txt"
+    _write_key_text(ref_file, [("utt1", "你好")])
+    _write_key_text(hyp_file, [("utt1", "你好")])
+
+    report = evaluate_asr_files(str(ref_file), str(hyp_file), language="cs", metric="mer")
+    result = report.details["scoring_result"]
+
+    assert report.score == 0.0
+    assert result["wer"] == 0.0
+    assert result["wer_details"]["all"] == 0


### PR DESCRIPTION
### Problem

Three silent-failure paths in the ASR scoring pipeline understate error rates or report perfect scores on broken inputs:

1. **Empty hypothesis text is dropped.** `aispeech_norm` keeps only rows that split into two tab-separated fields, so an empty recognition result (`key\t`) is discarded, and `compute_wer` then skips the matching reference row (`fid not in rec_set`). The worst utterances — where the model produced nothing — are excluded from CER/WER/MER entirely. On a benchmark set where ~half the hypotheses are legitimately empty, corpus CER is understated by up to ~50%.
2. **Missing hypothesis utterances are skipped silently**, with no utterance counts anywhere in the report, so a partial or key-mismatched hypothesis file passes as a clean run.
3. **Malformed input scores 0.0.** A space-separated (Kaldi-style) file parses to zero rows, and `all == 0` maps to a perfect 0.0 error rate with no warning.

### Changes

- `normalization/aispeech_norm`: keep empty-text rows (scored as deletions downstream), report `row_stats` (rows / empty / dropped-malformed) in the node trace, and raise when a file yields no parseable `<key>\t<text>` rows.
- `scoring/wenet_*` wrapper: score reference utterances missing from the hypothesis as empty hypotheses (pure deletions), expose utterance coverage (`num_ref_utts`, `num_hyp_utts`, `num_hyp_missing_utts`, `num_hyp_extra_utts`, key samples) in the scoring result, and refuse to report 0.0 when zero reference tokens were covered. Code-switch zh/en side scores stay lenient (monolingual subsets legitimately cover zero tokens).
- Performance, bit-identical scores: reset only the DP submatrix each utterance uses in the vendored `compute_wer` (one long utterance previously made every following utterance pay `O(longest²)`; 17x on a synthetic corpus, ~10x end-to-end on a real 1.4k-utterance code-switch run), and preload normalization map tables once per node call instead of re-globbing/re-reading per line or token (~40x per-call overhead).
- Fix a latent `NameError` in `asr_num2words`' fallback map loading (`load_and_sort_map` referenced but never defined).

### Tests

Nine new regression cases (`tests/test_asr_scoring_coverage.py`) covering empty/missing hypotheses, coverage reporting, zero-token rejection, order-independent totals, and monolingual code-switch side scores. Legacy parity tests now subset-compare: scoring results may add coverage fields, but every legacy field must still match exactly.